### PR TITLE
Añado comentarios y explicación al ejemplo PHP y la conf de Sphinx

### DIFF
--- a/src/sphinx/README.md
+++ b/src/sphinx/README.md
@@ -1,0 +1,7 @@
+Here you can find a commented version of a php script connecting to Sphinx to execute queries.
+Also a commented Sphinx configuration file.
+
+Install composer dependencies by running
+```
+composer install
+```

--- a/src/sphinx/composer.json
+++ b/src/sphinx/composer.json
@@ -1,0 +1,5 @@
+{
+  "require": {
+    "gigablah/sphinxphp": "^2.0"
+  }
+}

--- a/src/sphinx/demo.conf
+++ b/src/sphinx/demo.conf
@@ -1,3 +1,4 @@
+# We define a source, in this case only the connection parameters are set
 source mysql_common
 {
 	type		= mysql
@@ -8,9 +9,17 @@ source mysql_common
 	sql_port	= 3306
 }
 
+# The ':' means inheritance. The source 'municipios' inherits from 'mysql_common'
 source municipios : mysql_common
 {
 	sql_query_pre	= SET NAMES utf8
+	####################################################################################################################
+	## Write the query that Sphinx will use to create the full-text search index.
+	## Fields selected in the query will be used to create the index and search.
+	##
+	## The first field will be used for Sphinx to identify the matching rows when returning results.
+	## It's mandatory to have an id.
+	####################################################################################################################
 	sql_query	= \
 	 SELECT \
 	 	m.id_municipio,  \
@@ -18,29 +27,84 @@ source municipios : mysql_common
 	 	m.cod_municipio,  \
 	 	m.DC,  \
 	 	m.nombre as municipio, \
-     		p.provincia \
+     	p.provincia \
      FROM \
      	municipios m \
      	LEFT JOIN provincias p USING(id_provincia);
-    
+
+    ####################################################################################################################
+    ## Attributes are values associated with each document that can be used to perform
+    ## filtering and sorting during search. This values are included in the results, together
+    ## with the id and the weight of the row, and they need to be selected in the query above.
+    ## Keep in mind that these attributes are not used for searching/querying. Sphinx won't search on
+    ## fields selected in the query that are marked as attributes.
+    ##
+    ## We can add as many attributes as we need.
+    ## For example, to add the field 'id_provincia' as attribute so Sphinx returns its value, we can
+    ## add it like this:
+    ##
+    ##      sql_attr_uint = id_provincia
+    ##
+    ## If we want to both add an attribute, and use it for searching/querying at the same time, we can add
+    ## a field declaration. To do this we use sql_field_string. For example if we want to search by 'municipio'
+    ## and use alphabetical order for the 'municipio' name, we can declare it like:
+    ##
+    ##      sql_field_string = municipio
+    ##
+    ##
+    ####################################################################################################################
 	sql_field_string	= municipio
 	sql_attr_uint		= id_provincia
 }
 
+# Let's create our index
 index municipios
 {
 	source			= municipios
 	path			= /var/lib/sphinx/data/municipios
-	docinfo			= extern
-	mlock			= 0
-	morphology		= none
-	#morphology		= libstemmer_es
-	enable_star     = 1
-	min_word_len	= 2
 	charset_type	= utf-8
-	html_strip = 0
+	######################################################################################################################
+	## We can define a morphology preprocessor to replace different forms of the same word with the base, normalized form.
+	## For instance, when the spanish word 'completar' is indexed, Sphinx will reduce the word to the 'stem',
+	## so it will match when we search for 'completo', 'completamente', etc.
+	######################################################################################################################
+	morphology		= libstemmer_es
+	# Only those words that are longer will be indexed. If min_word_len is 4, then 'the' won't be indexed, but 'they' will be.
+	min_word_len	= 2
+	# If we enable html_strip, sphinx queries won't match against html tag names like html, body, div...
+	html_strip      = 0
+	#############################################################################
+	## We can use wildcards in Sphinx to match substrings, like 'bar' inside 'barcelona'. To do this,
+	## we set enable_star to 1, and if the user searchs for 'bar', we really query sphinx for 'bar*',
+	## or even '*bar*'.
+	## If we want to use the wildcard before and after the keyword, we need to also set a min_infix_len.
+	## If we only want to use the wildcard after the keyword, we just need to set min_prefix_len.
+	## We can only use one of them at the same time.
+	## Queries shorter than those minumuns won't return any results.
+	#############################################################################
+	enable_star     = 1
 	#min_prefix_len=2
 	#min_infix_len=3
+	#############################################################################
+	## This table will tell Sphinx which characters are equivalent, and it's useful to make letters with
+	## accents equivalent to letters without accents, so if you search 'Gavà', it will return
+	## the same results as searching for 'Gava'.
+	## If we don't need this equivalence, we just omit the charset_table.
+	#############################################################################
+	charset_table   = 0..9, A..Z->a..z, _, -, a..z, U+410..U+42F->U+430..U+44F, U+430..U+44F, \
+    U+C7->U+E7, U+E7, \
+    U+D1->U+F1, U+F1, \
+    U+DD->y, U+FD->y, \
+    U+C0->a, U+C1->a, U+C2->a, U+C3->a, U+C4->a, U+C5->a, \
+    U+E0->a, U+E1->a, U+E2->a, U+E3->a, U+E4->a, U+E5->a, \
+    U+C8->e, U+C9->e, U+CA->e, U+CB->e, \
+    U+E8->e, U+E9->e, U+EA->e, U+EB->e, \
+    U+CC->i, U+CD->i, U+CE->i, U+CF->i, \
+    U+EC->i, U+ED->i, U+EE->i, U+EF->i, \
+    U+D2->o, U+D3->o, U+D4->o, U+D5->o, U+D6->o, \
+    U+F2->o, U+F3->o, U+F4->o, U+F5->o, U+F6->o, \
+    U+D9->u, U+DA->u, U+DB->u, U+DC->u, \
+    U+F9->u, U+FA->u, U+FB->u, U+FC->u
 
 }
 
@@ -80,5 +144,3 @@ searchd
 	max_filters			= 256
 	max_filter_values	= 4096
 }
-
-# --eof--

--- a/src/sphinx/search_example.php
+++ b/src/sphinx/search_example.php
@@ -1,32 +1,111 @@
 <?php
 
-include '/var/lib/sphinx/api/sphinxapi.php';
-$index = 'municipios';
+require_once __DIR__ . '/vendor/autoload.php';
 
-if ( !isset( $argv[1] ) )
-{
-    die( 'You need to specify a search term' );
+error_reporting(E_ALL);
+ini_set("display_errors", true);
+
+if (empty($_GET['q'])) {
+    echo 'Choose a query string like: <a href="search_example.php.php?q=barcelona">barcelona</a>';
+    die();
 }
 
-$query_string = $argv[1];
-$sphinx = new \SphinxClient();
-$sphinx->SetServer( '127.0.0.1', 9312);
-$sphinx->SetMatchMode( SPH_MATCH_EXTENDED );
-$sphinx->SetSortMode( SPH_SORT_RELEVANCE );
+// Create Sphinx client instance
+$sphinx = new \Sphinx\SphinxClient();
 
-// Restrict to Barcelona and Girona (id_provincia=8, id_provincia=17):
+// Set where the sphinx server (searchd) is running
+$sphinx->SetServer('localhost', "9312");
+
+/**
+ * We can select how sphinx will order the results.
+ *
+ * We'll use SPH_SORT_EXTENDED when we want SQL like ordering, selecting the fields to order by.
+ * For example, the default Sphinx order returns the same order as:
+ *
+ *      $sphinx->SetSortMode(\Sphinx\SphinxClient::SPH_SORT_EXTENDED, '@weight DESC, municipio ASC');
+ *
+ *
+ * ...where internal fields like 'weight' are prefixed by '@', while our own fields are not. We can order
+ * by any field that we've specified as sql_field_string or sql_attr_string in the index configuration.
+ *
+ * We'll use SPH_SORT_EXPR when we need to use some values/fields to calculate our own ranking. You can
+ * use Sphinx functions and expressions listed here http://sphinxsearch.com/docs/current/expressions.html
+ * For example, improving users' weight by adding user_karma and pageviews:
+ *
+ *      $sphinx->SetSortMode(\Sphinx\SphinxClient::SPH_SORT_EXPR, "@weight + (user_karma + ln(pageviews)) * 0.1");
+ *
+ *
+ * More info: http://sphinxsearch.com/docs/current/sorting-modes.html
+ */
+$sphinx->SetSortMode(\Sphinx\SphinxClient::SPH_SORT_EXTENDED, '@weight DESC, municipio ASC');
+
+// Choose the offset and limit for the query.
+$sphinx->SetLimits(0, 23);
+
+// We can restrict values on attributes.
+// Restrict attribute id_provincia to Barcelona and Girona (id_provincia=8, id_provincia=17):
 $sphinx->SetFilter( 'id_provincia', array( 8, 17 ) );
-// Returns the first 5 results, let's say we want the "page 1".
-$sphinx->SetLimits( 0, 5 );
 
-$sphinx->AddQuery( $query_string, $index );
-$results = $sphinx->RunQueries();
-if ( !empty( $results[0]['matches'] ) )
-{
-    var_dump( $results[0]['matches'] );
-    echo "Total matches: " . $results[0]['total_found'];
-}
-else
-{
-    die( "No results found for '$query_string'" );
+/**
+ * We've two different ways to execute sphinx queries.
+ * If you want to execute just one query, use:
+ *
+ *      $results = $sphinx->query('Barcelona', 'municipios');
+ *
+ * If you need to execute several queries at the same time, you can do it like these:
+ *
+ *      $sphinx->AddQuery('Barcelona', 'municipios');
+ *      $sphinx->AddQuery('Vigo', 'municipios');
+ *      $results = $sphinx->RunQueries();
+ *
+ *
+ * Returned array will contain a different key for every query.
+ *
+ * In both cases, if there is an error the function will return false. To see which error, use:
+ *
+ *      var_dump($sphinx->getLastError());
+ *      var_dump($sphinx->getLastWarning());
+ *
+ *
+ * If there were no errors, $results will be an array of matching documents with the following interesting fields:
+ *
+ *      - matches: Documents that matched the query
+ *      - total: How many documents have returned, depending on Sphinx configuration
+ *      - total_found: How many documents contain the query
+ *      - time: Time taken to perform the query
+ *      - words: Words that Sphinx tried to find
+ *
+ */
+?>
+
+
+
+    <!DOCTYPE html>
+    <html lang="es-ES">
+    <head>
+        <meta charset="utf-8">
+    </head>
+    <body>
+
+<?php
+/**
+ * Example that will search in Sphinx the query passed as query string, like:
+ * http://vagrant.dev:8080/sphinx/search_example.php?q=barcelona
+ *
+ * If we want to match substrings and we have 'enable_star' set to 1, we can use wildcards like
+ *
+ *      $results = $sphinx->query($_GET['q'] . "*", 'municipios');
+ */
+
+
+$results = $sphinx->query($_GET['q'], 'municipios');
+
+if (!$results) {
+    var_dump($sphinx->getLastError());
+    var_dump($sphinx->getLastWarning());
+}else{
+    echo "TOTAL: " . $results['total'] . "<br /><br />";
+    foreach($results['matches'] as $municipio) {
+        echo "{$municipio['attrs']['municipio']}<br />";
+    }
 }


### PR DESCRIPTION
Para no tener que refrescar cada año qué era cada cosa, he añadido explicaciones de cada directiva importante en el archivo de configuración de Sphinx.
Además, el script PHP de ejemplo también explica algunos modos de funcionamiento de Sphinx, y he cambiado para que se pueda ejecutar por URL pasando el término de búsqueda por query string.
También instala la librería de Sphinx con Composer.

Si ves algo mal o tal avisa!
